### PR TITLE
Make logging use SLF4J instead of Apache Commons Logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ target
 # Eclipse stuff
 .project
 .classpath
+.settings/
 
 # OS X stuff
 .DS_Store
+
+# general
+*~

--- a/src/main/java/org/d2rq/db/schema/Inspector.java
+++ b/src/main/java/org/d2rq/db/schema/Inspector.java
@@ -15,11 +15,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
-import org.apache.log4j.Logger;
 import org.d2rq.D2RQException;
 import org.d2rq.db.SQLConnection;
 import org.d2rq.db.types.DataType;
 import org.d2rq.db.vendor.Vendor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -31,7 +32,7 @@ import org.d2rq.db.vendor.Vendor;
  * @author Richard Cyganiak (richard@cyganiak.de)
  */
 public class Inspector {
-	private final static Logger log = Logger.getLogger(Inspector.class);
+	private final static Logger log = LoggerFactory.getLogger(Inspector.class);
 
 	private final Connection connection;
 	private final Vendor vendor;

--- a/src/main/java/org/d2rq/mapgen/D2RQTarget.java
+++ b/src/main/java/org/d2rq/mapgen/D2RQTarget.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import org.apache.log4j.Logger;
 import org.d2rq.db.SQLConnection;
 import org.d2rq.db.schema.ForeignKey;
 import org.d2rq.db.schema.Identifier;
@@ -21,6 +20,8 @@ import org.d2rq.lang.Mapping;
 import org.d2rq.lang.Microsyntax;
 import org.d2rq.lang.PropertyBridge;
 import org.d2rq.values.TemplateValueMaker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.ModelFactory;
@@ -30,7 +31,7 @@ import com.hp.hpl.jena.vocabulary.RDFS;
 import com.hp.hpl.jena.vocabulary.XSD;
 
 public class D2RQTarget implements Target {
-	private final static Logger log = Logger.getLogger(D2RQTarget.class);
+	private final static Logger log = LoggerFactory.getLogger(D2RQTarget.class);
 
 	private final Model model = ModelFactory.createDefaultModel();
 	private final Map<TableName,ClassMap> classMaps = 

--- a/src/main/java/org/d2rq/mapgen/MappingGenerator.java
+++ b/src/main/java/org/d2rq/mapgen/MappingGenerator.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.log4j.Logger;
 import org.d2rq.db.SQLConnection;
 import org.d2rq.db.schema.ColumnDef;
 import org.d2rq.db.schema.ForeignKey;
@@ -16,6 +15,8 @@ import org.d2rq.db.schema.TableName;
 import org.d2rq.db.types.DataType;
 import org.d2rq.lang.Microsyntax;
 import org.d2rq.values.TemplateValueMaker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.hp.hpl.jena.rdf.model.Property;
 import com.hp.hpl.jena.rdf.model.Resource;
@@ -32,7 +33,7 @@ import com.hp.hpl.jena.shared.impl.PrefixMappingImpl;
  * @author Richard Cyganiak (richard@cyganiak.de)
  */
 public class MappingGenerator {
-	private final static Logger log = Logger.getLogger(MappingGenerator.class);
+	private final static Logger log = LoggerFactory.getLogger(MappingGenerator.class);
 
 	private final MappingStyle style;
 	private final SQLConnection sqlConnection;

--- a/src/test/java/org/d2rq/csv/TranslationTableParserTest.java
+++ b/src/test/java/org/d2rq/csv/TranslationTableParserTest.java
@@ -7,29 +7,34 @@ import java.util.HashSet;
 import org.d2rq.D2RQTestUtil;
 import org.d2rq.csv.TranslationTableParser;
 import org.d2rq.lang.TranslationTable.Translation;
-
-import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
 
 /**
  * Unit tests for {@link TranslationTableParser}
  *
  * @author Richard Cyganiak (richard@cyganiak.de)
  */
-public class TranslationTableParserTest extends TestCase {
+public class TranslationTableParserTest {
+	
 	private Collection<Translation> simpleTranslations;
 	
+	@Before
 	public void setUp() {
 		this.simpleTranslations = new HashSet<Translation>();
 		this.simpleTranslations.add(new Translation("db1", "rdf1"));
 		this.simpleTranslations.add(new Translation("db2", "rdf2"));
 	}
 	
+	@Test
 	public void testEmpty() {
 		Collection<Translation> translations = new TranslationTableParser(
 				new StringReader("")).parseTranslations();
 		assertTrue(translations.isEmpty());
 	}
 	
+	@Test
 	public void testSimple() {
 		String csv = "key,value";
 		Collection<Translation> translations = new TranslationTableParser(
@@ -40,6 +45,7 @@ public class TranslationTableParserTest extends TestCase {
 		assertEquals("value", t.rdfValue());
 	}
 	
+	@Test
 	public void testTwoRows() {
 		String csv = "db1,rdf1\ndb2,rdf2";
 		Collection<Translation> translations = new TranslationTableParser(
@@ -48,12 +54,14 @@ public class TranslationTableParserTest extends TestCase {
 		assertEquals(this.simpleTranslations, new HashSet<Translation>(translations));
 	}
 	
+	@Test
 	public void testParseFromFile() {
 		Collection<Translation> translations = new TranslationTableParser(
 				D2RQTestUtil.getResourceURL("d2rq-reader/translationtable.csv")).parseTranslations();
 		assertEquals(this.simpleTranslations, new HashSet<Translation>(translations));
 	}
 	
+	@Test
 	public void testParseFromFileWithProtocol() {
 		Collection<Translation> translations = new TranslationTableParser(
 				D2RQTestUtil.getResourceURL("d2rq-reader/translationtable.csv")).parseTranslations();

--- a/src/test/java/org/d2rq/download/DownloadContentQueryTest.java
+++ b/src/test/java/org/d2rq/download/DownloadContentQueryTest.java
@@ -13,15 +13,20 @@ import org.d2rq.HSQLDatabase;
 import org.d2rq.algebra.DownloadRelation;
 import org.d2rq.download.DownloadContentQuery;
 import org.d2rq.lang.Mapping;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.*;
 
-public class DownloadContentQueryTest extends TestCase  {
+public class DownloadContentQueryTest {
+	
 	private HSQLDatabase db;
 	private DownloadRelation downloadCLOB;
 	private DownloadRelation downloadBLOB;
 	private DownloadContentQuery q;
 	
+	@Before
 	public void setUp() {
 		db = new HSQLDatabase("test");
 		db.executeSQL("CREATE TABLE People (ID INT NOT NULL PRIMARY KEY, PIC_CLOB CLOB NULL, PIC_BLOB BLOB NULL)");
@@ -39,16 +44,19 @@ public class DownloadContentQueryTest extends TestCase  {
 		}
 	}
 
+	@After
 	public void tearDown() {
 		db.close(true);
 		if (q != null) q.close();
 	}
 	
+	@Test
 	public void testFixture() {
 		assertNotNull(downloadCLOB);
 		assertNotNull(downloadBLOB);
 	}
 	
+	@Test
 	public void testNullForNonDownloadURI() {
 		q = new DownloadContentQuery(
 				downloadCLOB, "http://not-in-the-mapping");
@@ -56,6 +64,7 @@ public class DownloadContentQueryTest extends TestCase  {
 		assertNull(q.getContentStream());
 	}
 	
+	@Test
 	public void testNullForNonExistingRecord() {
 		// There is no People.ID=42 in the table
 		q = new DownloadContentQuery(
@@ -64,6 +73,7 @@ public class DownloadContentQueryTest extends TestCase  {
 		assertNull(q.getContentStream());
 	}
 	
+	@Test
 	public void testReturnCLOBContentForExistingRecord() throws IOException {
 		q = new DownloadContentQuery(
 				downloadCLOB, "http://example.org/downloads/clob/1");
@@ -71,6 +81,7 @@ public class DownloadContentQueryTest extends TestCase  {
 		assertEquals("Hello World!", inputStreamToString(q.getContentStream()));
 	}
 
+	@Test
 	public void testNULLContent() {
 		q = new DownloadContentQuery(
 				downloadCLOB, "http://example.org/downloads/clob/2");
@@ -78,6 +89,7 @@ public class DownloadContentQueryTest extends TestCase  {
 		assertNull(q.getContentStream());
 	}
 	
+	@Test
 	public void testReturnBLOBContentForExistingRecord() throws IOException {
 		q = new DownloadContentQuery(downloadBLOB, "http://example.org/downloads/blob/2");
 		assertTrue(q.hasContent());

--- a/src/test/java/org/d2rq/lang/ConstantValueClassMapTest.java
+++ b/src/test/java/org/d2rq/lang/ConstantValueClassMapTest.java
@@ -6,15 +6,16 @@ import org.d2rq.lang.D2RQValidator;
 import org.d2rq.lang.Database;
 import org.d2rq.lang.Mapping;
 import org.d2rq.lang.PropertyBridge;
-
-import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
 
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.ModelFactory;
 import com.hp.hpl.jena.vocabulary.RDF;
 
+import static org.junit.Assert.*;
 
-public class ConstantValueClassMapTest extends TestCase {
+public class ConstantValueClassMapTest {
 	
 	private Model model;
 	private Mapping mapping;
@@ -51,6 +52,7 @@ public class ConstantValueClassMapTest extends TestCase {
 		return result;
 	}
 	
+	@Before
 	public void setUp() {
 		this.model = ModelFactory.createDefaultModel();
 		this.mapping = new Mapping();
@@ -70,8 +72,8 @@ public class ConstantValueClassMapTest extends TestCase {
 		memberBridge.addCondition("c.foo = 1");
 	}
 	
-	public void testValidate()
-	{
+	@Test
+	public void testValidate() {
 		try {
 			collection.accept(new D2RQValidator(null));
 		} catch (D2RQException e) {

--- a/src/test/java/org/d2rq/lang/TranslationTableTest.java
+++ b/src/test/java/org/d2rq/lang/TranslationTableTest.java
@@ -3,32 +3,36 @@ package org.d2rq.lang;
 import org.d2rq.lang.TranslationTable;
 import org.d2rq.lang.TranslationTable.Translation;
 import org.d2rq.values.Translator;
-
-import junit.framework.TestCase;
+import org.junit.Test;
 
 import com.hp.hpl.jena.rdf.model.Resource;
 import com.hp.hpl.jena.rdf.model.ResourceFactory;
 
+import static org.junit.Assert.*;
 
 /**
  * Tests the TranslationTable functionality
  *
  * @author Richard Cyganiak (richard@cyganiak.de)
  */
-public class TranslationTableTest extends TestCase {
+public class TranslationTableTest {
+	
 	Resource table1 = ResourceFactory.createResource("http://test/table1");
 
+	@Test
 	public void testNewTranslationTableIsEmpty() {
 		TranslationTable table = new TranslationTable(table1);
 		assertEquals(0, table.size());
 	}
 	
+	@Test
 	public void testTranslationTableIsSizeOneAfterAddingOneTranslation() {
 		TranslationTable table = new TranslationTable(table1);
 		table.addTranslation("key1", "value1");
 		assertEquals(1, table.size());
 	}
 
+	@Test
 	public void testTranslationTableTranslator() {
 		TranslationTable table = new TranslationTable(table1);
 		table.addTranslation("key1", "value1");
@@ -41,6 +45,7 @@ public class TranslationTableTest extends TestCase {
 		assertEquals("key2", translator.toDBValue("value2"));
 	}
 
+	@Test
 	public void testUndefinedTranslation() {
 		TranslationTable table = new TranslationTable(table1);
 		table.addTranslation("key1", "value1");
@@ -49,6 +54,7 @@ public class TranslationTableTest extends TestCase {
 		assertNull(translator.toDBValue("http://example.org/"));
 	}
 	
+	@Test
 	public void testNullTranslation() {
 		TranslationTable table = new TranslationTable(table1);
 		table.addTranslation("key1", "value1");
@@ -57,6 +63,7 @@ public class TranslationTableTest extends TestCase {
 		assertNull(translator.toDBValue(null));
 	}
 	
+	@Test
 	public void testTranslationsWithSameValuesAreEqual() {
 		Translation t1 = new Translation("foo", "bar");
 		Translation t2 = new Translation("foo", "bar");
@@ -64,6 +71,7 @@ public class TranslationTableTest extends TestCase {
 		assertEquals(t1.hashCode(), t2.hashCode());
 	}
 	
+	@Test
 	public void testTranslationsWithDifferentValuesAreNotEqual() {
 		Translation t1 = new Translation("foo", "bar");
 		Translation t2 = new Translation("foo", "bar2");

--- a/src/test/java/org/d2rq/mapgen/FilterParserTest.java
+++ b/src/test/java/org/d2rq/mapgen/FilterParserTest.java
@@ -6,59 +6,73 @@ import org.d2rq.mapgen.Filter;
 import org.d2rq.mapgen.FilterParser;
 import org.d2rq.mapgen.Filter.IdentifierMatcher;
 import org.d2rq.mapgen.FilterParser.ParseException;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.*;
 
-public class FilterParserTest extends TestCase {
+public class FilterParserTest {
 
+	@Test
 	public void testEmpty() throws ParseException {
 		assertEquals("", toString(new FilterParser("").parse()));
 	}
 	
+	@Test
 	public void testSimple() throws ParseException {
 		assertEquals("'foo'", toString(new FilterParser("foo").parse()));
 	}
 	
+	@Test
 	public void testMultipleStrings() throws ParseException {
 		assertEquals("'foo'.'bar'", toString(new FilterParser("foo.bar").parse()));
 	}
 	
+	@Test
 	public void testMultipleFilters() throws ParseException {
 		assertEquals("'foo','bar'", toString(new FilterParser("foo,bar").parse()));
 	}
 	
+	@Test
 	public void testMultipleFiltersNewline() throws ParseException {
 		assertEquals("'foo','bar'", toString(new FilterParser("foo\n\rbar").parse()));
 	}
 	
+	@Test
 	public void testRegex() throws ParseException {
 		assertEquals("/foo/0", toString(new FilterParser("/foo/").parse()));
 	}
 
+	@Test
 	public void testRegexWithFlag() throws ParseException {
 		assertEquals("/foo/2", toString(new FilterParser("/foo/i").parse()));
 	}
 
+	@Test
 	public void testMutlipleRegexes() throws ParseException {
 		assertEquals("/foo/0./bar/0", toString(new FilterParser("/foo/./bar/").parse()));
 	}
 
+	@Test
 	public void testMutlipleRegexFilters() throws ParseException {
 		assertEquals("/foo/0,/bar/0", toString(new FilterParser("/foo/,/bar/").parse()));
 	}
 
+	@Test
 	public void testDotInRegex() throws ParseException {
 		assertEquals("/foo.bar/0", toString(new FilterParser("/foo.bar/").parse()));
 	}
 
+	@Test
 	public void testEscapedDotInRegex() throws ParseException {
 		assertEquals("/foo\\.bar/0", toString(new FilterParser("/foo\\.bar/").parse()));
 	}
 
+	@Test
 	public void testCommaInRegex() throws ParseException {
 		assertEquals("/foo,bar/0", toString(new FilterParser("/foo,bar/").parse()));
 	}
 
+	@Test
 	public void testIncompleteRegex() {
 		try {
 			new FilterParser("/foo").parse();
@@ -68,6 +82,7 @@ public class FilterParserTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testIncompleteRegexNewline() {
 		try {
 			new FilterParser("/foo\nbar/").parse();
@@ -77,11 +92,13 @@ public class FilterParserTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testComplex() throws ParseException {
 		assertEquals("/.*/0.'CHECKSUM','USER'.'PASSWORD'",
 				toString(new FilterParser("/.*/.CHECKSUM,USER.PASSWORD").parse()));
 	}
 	
+	@Test
 	public void testParseAsSchemaFilter() throws ParseException {
 		Filter result = new FilterParser("schema1,schema2").parseSchemaFilter();
 		assertTrue(result.matchesSchema("schema1"));
@@ -90,6 +107,7 @@ public class FilterParserTest extends TestCase {
 		assertFalse(result.matchesSchema(null));
 	}
 	
+	@Test
 	public void testParseAsSchemaFilterWithRegex() throws ParseException {
 		Filter result = new FilterParser("/schema[12]/i").parseSchemaFilter();
 		assertTrue(result.matchesSchema("schema1"));
@@ -97,7 +115,8 @@ public class FilterParserTest extends TestCase {
 		assertFalse(result.matchesSchema("schema3"));
 		assertFalse(result.matchesSchema(null));
 	}
-	
+
+	@Test
 	public void testParseAsSchemaFilterFail() {
 		try {
 			new FilterParser("schema.table").parseSchemaFilter();
@@ -107,6 +126,7 @@ public class FilterParserTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testParseAsTableFilter() throws ParseException {
 		Filter result = new FilterParser("schema.table1,schema.table2,table3").parseTableFilter(false);
 		assertTrue(result.matchesTable("schema", "table1"));
@@ -119,6 +139,7 @@ public class FilterParserTest extends TestCase {
 		assertFalse(result.matchesTable(null, "table4"));
 	}
 	
+	@Test
 	public void testTableFilterTooMany() {
 		try {
 			new FilterParser("a.b.c").parseTableFilter(true);
@@ -128,6 +149,7 @@ public class FilterParserTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testParseAsColumnFilter() throws ParseException {
 		Filter result = new FilterParser("s.t1.c1,t2.c2,t2.c3").parseColumnFilter(false);
 		assertTrue(result.matchesColumn("s", "t1", "c1"));

--- a/src/test/java/org/d2rq/mapgen/IRIEncoderTest.java
+++ b/src/test/java/org/d2rq/mapgen/IRIEncoderTest.java
@@ -1,19 +1,23 @@
 package org.d2rq.mapgen;
 
 import org.d2rq.mapgen.IRIEncoder;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.*;
 
-public class IRIEncoderTest extends TestCase {
+public class IRIEncoderTest {
 	
+	@Test
 	public void testDontEncodeAlphanumeric() {
 		assertEquals("azAZ09", IRIEncoder.encode("azAZ09"));
 	}
 	
+	@Test
 	public void testDontEncodeSafePunctuation() {
 		assertEquals("-_.~", IRIEncoder.encode("-_.~"));
 	}
 	
+	@Test
 	public void testDontEncodeUnicodeChars() {
 		// This is 'LATIN SMALL LETTER A WITH DIAERESIS' (U+00E4)
 		assertEquals("\u00E4", IRIEncoder.encode("\u00E4"));
@@ -23,22 +27,27 @@ public class IRIEncoderTest extends TestCase {
 	    assertEquals("\uFFEF", IRIEncoder.encode("\uFFEF"));
 	}
 
+	@Test
 	public void testEncodeGenDelims() {
 		assertEquals("%3A%2F%3F%23%5B%5D%40", IRIEncoder.encode(":/?#[]@"));
 	}
 	
+	@Test
 	public void testEncodeSubDelims() {
 		assertEquals("%21%24%26%27%28%29%2A%2B%2C%3B%3D", IRIEncoder.encode("!$&'()*+,;="));
 	}
 	
+	@Test
 	public void testEncodePercentSign() {
 		assertEquals("%25", IRIEncoder.encode("%"));		
 	}
 	
+	@Test
 	public void testEncodeOtherASCIIChars() {
 		assertEquals("%20%22%3C%3E%5C%5E%60%7B%7C%7D", IRIEncoder.encode(" \"<>\\^`{|}"));
 	}
 	
+	@Test
 	public void testEncodeASCIIControlChars() {
 		assertEquals("%00%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F",
 				IRIEncoder.encode("\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u0009\n\u000B\u000C\r\u000E\u000F"));
@@ -47,6 +56,7 @@ public class IRIEncoderTest extends TestCase {
 		assertEquals("%7F", IRIEncoder.encode("\u007F"));
 	}
 	
+	@Test
 	public void testEncodeUnicodeControlChars() {
 		assertEquals("%C2%80", IRIEncoder.encode("\u0080"));
 		assertEquals("%C2%9F", IRIEncoder.encode("\u009F"));

--- a/src/test/java/org/d2rq/vocab/VocabularySummarizerTest.java
+++ b/src/test/java/org/d2rq/vocab/VocabularySummarizerTest.java
@@ -8,8 +8,7 @@ import org.d2rq.vocab.D2RConfig;
 import org.d2rq.vocab.D2RQ;
 import org.d2rq.vocab.RR;
 import org.d2rq.vocab.VocabularySummarizer;
-
-import junit.framework.TestCase;
+import org.junit.Test;
 
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.ModelFactory;
@@ -17,86 +16,102 @@ import com.hp.hpl.jena.rdf.model.Property;
 import com.hp.hpl.jena.rdf.model.Resource;
 import com.hp.hpl.jena.vocabulary.RDF;
 
+import static org.junit.Assert.*;
 
+public class VocabularySummarizerTest {
 
-public class VocabularySummarizerTest extends TestCase {
-
+	@Test
 	public void testAllPropertiesEmpty() {
 		VocabularySummarizer vocab = new VocabularySummarizer(Object.class);
 		assertTrue(vocab.getAllProperties().isEmpty());
 	}
 	
+	@Test
 	public void testAllClassesEmpty() {
 		VocabularySummarizer vocab = new VocabularySummarizer(Object.class);
 		assertTrue(vocab.getAllClasses().isEmpty());
 	}
 	
+	@Test
 	public void testAllPropertiesContainsProperty() {
 		VocabularySummarizer vocab = new VocabularySummarizer(D2RQ.class);
 		assertTrue(vocab.getAllProperties().contains(D2RQ.column));
 		assertTrue(vocab.getAllProperties().contains(D2RQ.belongsToClassMap));
 	}
 	
+	@Test
 	public void testAllPropertiesDoesNotContainClass() {
 		VocabularySummarizer vocab = new VocabularySummarizer(D2RQ.class);
 		assertFalse(vocab.getAllProperties().contains(D2RQ.Database));
 	}
 	
+	@Test
 	public void testAllPropertiesDoesNotContainTermFromOtherNamespace() {
 		VocabularySummarizer vocab = new VocabularySummarizer(D2RQ.class);
 		assertFalse(vocab.getAllProperties().contains(RDF.type));
 	}
 
+	@Test
 	public void testAllClassesContainsClass() {
 		VocabularySummarizer vocab = new VocabularySummarizer(D2RQ.class);
 		assertTrue(vocab.getAllClasses().contains(D2RQ.Database));
 	}
 	
+	@Test
 	public void testAllClassesDoesNotContainProperty() {
 		VocabularySummarizer vocab = new VocabularySummarizer(D2RQ.class);
 		assertFalse(vocab.getAllClasses().contains(D2RQ.column));
 	}
 	
+	@Test
 	public void testAllClassesDoesNotContainTermFromOtherNamespace() {
 		VocabularySummarizer vocab = new VocabularySummarizer(D2RQ.class);
 		assertFalse(vocab.getAllClasses().contains(D2RConfig.Server));
 	}
 	
+	@Test
 	public void testGetNamespaceEmpty() {
 		assertNull(new VocabularySummarizer(Object.class).getNamespace());
 	}
 	
+	@Test
 	public void testGetNamespaceD2RQ() {
 		assertEquals(D2RQ.NS, new VocabularySummarizer(D2RQ.class).getNamespace());		
 	}
 
+	@Test
 	public void testGetNamespaceD2RConfig() {
 		assertEquals(D2RConfig.NS, new VocabularySummarizer(D2RConfig.class).getNamespace());		
 	}
 	
+	@Test
 	public void testNoUndefinedClassesForEmptyModel() {
 		VocabularySummarizer vocab = new VocabularySummarizer(D2RQ.class);
 		assertTrue(vocab.getUndefinedClasses(ModelFactory.createDefaultModel()).isEmpty());
 	}
 	
+	@Test
 	public void testNoUndefinedClassesWithoutTypeStatement() {
 		Model m = D2RQTestUtil.loadTurtle("vocab-summarizer/no-type.ttl");
 		VocabularySummarizer vocab = new VocabularySummarizer(D2RQ.class);
 		assertTrue(vocab.getUndefinedClasses(m).isEmpty());
 	}
 	
+	@Test
 	public void testNoUndefinedClassesIfAllClassesDefined() {
 		Model m = D2RQTestUtil.loadTurtle("vocab-summarizer/defined-types.ttl");
 		VocabularySummarizer vocab = new VocabularySummarizer(D2RQ.class);
 		assertTrue(vocab.getUndefinedClasses(m).isEmpty());
 	}
 	
+	@Test
 	public void testNoUndefinedClassesIfAllInOtherNamespace() {
 		Model m = D2RQTestUtil.loadTurtle("vocab-summarizer/other-namespace-types.ttl");
 		VocabularySummarizer vocab = new VocabularySummarizer(D2RQ.class);
 		assertTrue(vocab.getUndefinedClasses(m).isEmpty());
 	}
 	
+	@Test
 	public void testFindOneUndefinedClass() {
 		final Model m = D2RQTestUtil.loadTurtle("vocab-summarizer/one-undefined-type.ttl");
 		VocabularySummarizer vocab = new VocabularySummarizer(D2RQ.class);
@@ -106,6 +121,7 @@ public class VocabularySummarizerTest extends TestCase {
 		assertEquals(expected, vocab.getUndefinedClasses(m));
 	}
 	
+	@Test
 	public void testFindTwoUndefinedClasses() {
 		final Model m = D2RQTestUtil.loadTurtle("vocab-summarizer/two-undefined-types.ttl");
 		VocabularySummarizer vocab = new VocabularySummarizer(D2RQ.class);
@@ -116,23 +132,27 @@ public class VocabularySummarizerTest extends TestCase {
 		assertEquals(expected, vocab.getUndefinedClasses(m));
 	}
 	
+	@Test
 	public void testNoUndefinedPropertiesForEmptyModel() {
 		VocabularySummarizer vocab = new VocabularySummarizer(D2RQ.class);
 		assertTrue(vocab.getUndefinedProperties(ModelFactory.createDefaultModel()).isEmpty());
 	}
 	
+	@Test
 	public void testNoUndefinedPropertiesIfAllPropertiesDefined() {
 		Model m = D2RQTestUtil.loadTurtle("vocab-summarizer/defined-properties.ttl");
 		VocabularySummarizer vocab = new VocabularySummarizer(D2RQ.class);
 		assertTrue(vocab.getUndefinedProperties(m).isEmpty());
 	}
 	
+	@Test
 	public void testNoUndefinedPropertiesIfAllInOtherNamespace() {
 		Model m = D2RQTestUtil.loadTurtle("vocab-summarizer/other-namespace-properties.ttl");
 		VocabularySummarizer vocab = new VocabularySummarizer(D2RQ.class);
 		assertTrue(vocab.getUndefinedProperties(m).isEmpty());
 	}
 	
+	@Test
 	public void testFindOneUndefinedProperty() {
 		final Model m = D2RQTestUtil.loadTurtle("vocab-summarizer/one-undefined-property.ttl");
 		VocabularySummarizer vocab = new VocabularySummarizer(D2RQ.class);
@@ -142,6 +162,7 @@ public class VocabularySummarizerTest extends TestCase {
 		assertEquals(expected, vocab.getUndefinedProperties(m));
 	}
 	
+	@Test
 	public void testFindTwoUndefinedProperties() {
 		final Model m = D2RQTestUtil.loadTurtle("vocab-summarizer/two-undefined-properties.ttl");
 		VocabularySummarizer vocab = new VocabularySummarizer(D2RQ.class);
@@ -152,6 +173,7 @@ public class VocabularySummarizerTest extends TestCase {
 		assertEquals(expected, vocab.getUndefinedProperties(m));
 	}
 	
+	@Test
 	public void testUsesVocabulary() {
 		final Model m = D2RQTestUtil.loadTurtle("vocab-summarizer/rr-example.ttl");
 		assertTrue(new VocabularySummarizer(RR.class).usesVocabulary(m));


### PR DESCRIPTION
added `LoggerFactory` for usage of SLF4J, as suggested in the TODO and reported in #1 
